### PR TITLE
chore(client): add gitignore

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,43 @@
+# dependencies
+/node_modules/
+/.pnp
+.pnp.js
+
+# production build output
+/dist/
+/coverage/
+
+# misc
+.DS_Store
+Thumbs.db
+
+# local env files
+.env
+.env.local
+.env.*.local
+
+# log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# editor directories and files
+.idea/
+.vscode/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Yarn Berry directories
+.yarn/*
+!.yarn/cache
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+.yarnrc.yml


### PR DESCRIPTION
## Summary
- add a dedicated .gitignore for the client application to keep build artifacts, dependencies, and local files out of version control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c925c9e878832dae25ae7036c7bff2