### PR TITLE
feat: add react client scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # vue2-blog
 基于 vue2 + element-ui + node.js + mongodb 的个人博客
+
+## React 重构版前端
+
+`client-react/` 目录提供了使用 Vite 7 + React 18 + Tailwind CSS v4 + Ant Design 5 搭建的全新前端项目骨架，作为未来迁移到现代技术栈的基础。通过 `npm install` 安装依赖后，可执行以下脚本快速启动：
+
+```bash
+npm run dev     # 开发环境调试
+npm run build   # 生产构建
+npm run preview # 构建结果预览
+```

--- a/client-react/README.md
+++ b/client-react/README.md
@@ -1,0 +1,29 @@
+# React Client (Vite 7 + React 18 + Tailwind CSS v4 + Ant Design 5)
+
+该目录包含基于 Vite 7、React 18、Tailwind CSS v4 以及 Ant Design 5 组件库重新构建的前端工程。
+
+## 可用脚本
+
+- `npm run dev` - 启动本地开发服务器。
+- `npm run build` - 产出生产环境构建文件。
+- `npm run preview` - 预览生产构建结果。
+- `npm run lint` - 运行 ESLint 进行代码检查。
+- `npm run format` - 使用 Prettier 校验代码风格。
+
+## 目录结构
+
+```
+client-react/
+├─ index.html
+├─ package.json
+├─ src/
+│  ├─ App.tsx
+│  ├─ main.tsx
+│  ├─ components/
+│  ├─ layouts/
+│  ├─ pages/
+│  └─ styles/
+└─ tailwind.config.ts
+```
+
+`src/pages/HomePage.tsx` 为示例仪表盘页面，演示了如何同时使用 Tailwind CSS 的原子类与 Ant Design 组件进行快速开发。

--- a/client-react/eslint.config.js
+++ b/client-react/eslint.config.js
@@ -1,0 +1,40 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import reactRefreshPlugin from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["dist"] },
+  {
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+      reactPlugin.configs.recommended,
+      reactPlugin.configs["jsx-runtime"]
+    ],
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        project: ["./tsconfig.json"],
+        tsconfigRootDir: import.meta.dirname
+      }
+    },
+    plugins: {
+      "react-hooks": reactHooksPlugin,
+      "react-refresh": reactRefreshPlugin
+    },
+    settings: {
+      react: {
+        version: "detect"
+      }
+    },
+    rules: {
+      ...reactHooksPlugin.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }]
+    }
+  }
+);

--- a/client-react/index.html
+++ b/client-react/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue2 Blog React Client</title>
+  </head>
+  <body class="bg-slate-50 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "client-react",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --max-warnings 0",
+    "format": "prettier --check ."
+  },
+  "dependencies": {
+    "antd": "^5.17.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@ant-design/icons": "^5.3.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.3",
+    "@vitejs/plugin-react-swc": "^3.7.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.11",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^4.0.0-alpha.13",
+    "typescript": "^5.5.4",
+    "vite": "^7.0.0-alpha.0",
+    "@eslint/js": "^9.9.0",
+    "eslint-plugin-react": "^7.35.0",
+    "globals": "^15.8.0",
+    "typescript-eslint": "^8.3.0",
+    "prettier": "^3.3.3",
+    "@types/node": "^20.14.10"
+  }
+}

--- a/client-react/postcss.config.cjs
+++ b/client-react/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/client-react/src/App.tsx
+++ b/client-react/src/App.tsx
@@ -1,0 +1,12 @@
+import { DashboardLayout } from "./layouts/DashboardLayout";
+import { HomePage } from "./pages/HomePage";
+
+const App = () => {
+  return (
+    <DashboardLayout>
+      <HomePage />
+    </DashboardLayout>
+  );
+};
+
+export default App;

--- a/client-react/src/components/AppHeader.tsx
+++ b/client-react/src/components/AppHeader.tsx
@@ -1,0 +1,38 @@
+import { Layout, Menu, Typography } from "antd";
+import { FireOutlined } from "@ant-design/icons";
+
+const { Header } = Layout;
+
+const items = [
+  {
+    key: "home",
+    label: "首页"
+  },
+  {
+    key: "articles",
+    label: "文章"
+  },
+  {
+    key: "about",
+    label: "关于"
+  }
+];
+
+export const AppHeader = () => {
+  return (
+    <Header className="sticky top-0 z-10 flex items-center justify-between bg-white/90 px-6 shadow-sm backdrop-blur">
+      <div className="flex items-center gap-2">
+        <FireOutlined className="text-2xl text-brand" />
+        <Typography.Title level={4} className="!mb-0">
+          Vue2 Blog
+        </Typography.Title>
+      </div>
+      <Menu
+        className="flex-1 justify-end border-none text-base"
+        mode="horizontal"
+        defaultSelectedKeys={["home"]}
+        items={items}
+      />
+    </Header>
+  );
+};

--- a/client-react/src/components/AppSider.tsx
+++ b/client-react/src/components/AppSider.tsx
@@ -1,0 +1,50 @@
+import { Layout, Menu } from "antd";
+import {
+  HomeOutlined,
+  BookOutlined,
+  UserOutlined,
+  SettingOutlined
+} from "@ant-design/icons";
+
+const { Sider } = Layout;
+
+const menuItems = [
+  {
+    key: "dashboard",
+    icon: <HomeOutlined />,
+    label: "仪表盘"
+  },
+  {
+    key: "posts",
+    icon: <BookOutlined />,
+    label: "文章管理"
+  },
+  {
+    key: "profile",
+    icon: <UserOutlined />,
+    label: "个人中心"
+  },
+  {
+    key: "settings",
+    icon: <SettingOutlined />,
+    label: "系统设置"
+  }
+];
+
+export const AppSider = () => {
+  return (
+    <Sider
+      width={220}
+      breakpoint="lg"
+      collapsedWidth={64}
+      className="bg-white/80 backdrop-blur"
+    >
+      <Menu
+        mode="inline"
+        defaultSelectedKeys={["dashboard"]}
+        items={menuItems}
+        className="border-none text-base"
+      />
+    </Sider>
+  );
+};

--- a/client-react/src/layouts/DashboardLayout.tsx
+++ b/client-react/src/layouts/DashboardLayout.tsx
@@ -1,0 +1,23 @@
+import { Layout } from "antd";
+import { PropsWithChildren } from "react";
+import { AppHeader } from "../components/AppHeader";
+import { AppSider } from "../components/AppSider";
+
+const { Content, Footer } = Layout;
+
+export const DashboardLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <Layout className="min-h-screen">
+      <AppHeader />
+      <Layout className="bg-transparent">
+        <AppSider />
+        <Content className="mx-6 my-4 rounded-xl bg-white p-6 shadow-sm">
+          {children}
+        </Content>
+      </Layout>
+      <Footer className="text-center text-xs text-slate-500">
+        Vue2 Blog React Client &copy; {new Date().getFullYear()} Created with Vite 7 + React 18
+      </Footer>
+    </Layout>
+  );
+};

--- a/client-react/src/main.tsx
+++ b/client-react/src/main.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { ConfigProvider } from "antd";
+import zhCN from "antd/locale/zh_CN";
+import App from "./App";
+import "antd/dist/reset.css";
+import "./styles/tailwind.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <ConfigProvider
+      locale={zhCN}
+      theme={{
+        token: {
+          colorPrimary: "#1677ff",
+          fontFamily: "'Inter', 'PingFang SC', 'Microsoft YaHei', sans-serif"
+        }
+      }}
+    >
+      <App />
+    </ConfigProvider>
+  </React.StrictMode>
+);

--- a/client-react/src/pages/HomePage.tsx
+++ b/client-react/src/pages/HomePage.tsx
@@ -1,0 +1,87 @@
+import { Card, Col, Row, Space, Statistic, Typography } from "antd";
+import { CalendarOutlined, LikeOutlined, MessageOutlined } from "@ant-design/icons";
+
+const stats = [
+  {
+    title: "本月阅读",
+    value: 12450,
+    suffix: "次",
+    icon: <LikeOutlined className="text-lg text-brand" />
+  },
+  {
+    title: "新增评论",
+    value: 318,
+    suffix: "条",
+    icon: <MessageOutlined className="text-lg text-brand" />
+  },
+  {
+    title: "发布文章",
+    value: 12,
+    suffix: "篇",
+    icon: <CalendarOutlined className="text-lg text-brand" />
+  }
+];
+
+const timeline = [
+  {
+    title: "深入理解React 18并发特性",
+    excerpt: "并发渲染为复杂交互带来了更多的性能空间...",
+    date: "2024-05-18"
+  },
+  {
+    title: "Vite 7项目最佳实践",
+    excerpt: "在企业级项目中使用Vite 7需要关注哪些细节?",
+    date: "2024-05-10"
+  },
+  {
+    title: "Tailwind CSS v4探索",
+    excerpt: "一文带你了解Tailwind CSS v4的设计理念与落地方式...",
+    date: "2024-04-26"
+  }
+];
+
+export const HomePage = () => {
+  return (
+    <Space direction="vertical" size="large" className="w-full">
+      <div>
+        <Typography.Title level={3} className="!mb-1">
+          控制台概览
+        </Typography.Title>
+        <Typography.Paragraph type="secondary" className="!mb-0">
+          快速查看站点运行情况，掌握内容创作节奏。
+        </Typography.Paragraph>
+      </div>
+      <Row gutter={[16, 16]}>
+        {stats.map((item) => (
+          <Col xs={24} md={8} key={item.title}>
+            <Card className="h-full">
+              <Statistic
+                title={
+                  <div className="flex items-center gap-2">
+                    {item.icon}
+                    <span>{item.title}</span>
+                  </div>
+                }
+                value={item.value}
+                suffix={item.suffix}
+              />
+            </Card>
+          </Col>
+        ))}
+      </Row>
+      <Card title="最新动态">
+        <Space direction="vertical" size={16} className="w-full">
+          {timeline.map((item) => (
+            <div key={item.title} className="rounded-lg border border-slate-100 p-4">
+              <Typography.Title level={5}>{item.title}</Typography.Title>
+              <Typography.Paragraph type="secondary">{item.excerpt}</Typography.Paragraph>
+              <Typography.Text className="text-xs text-slate-500">
+                {item.date}
+              </Typography.Text>
+            </div>
+          ))}
+        </Space>
+      </Card>
+    </Space>
+  );
+};

--- a/client-react/src/styles/tailwind.css
+++ b/client-react/src/styles/tailwind.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  @apply text-brand;
+}

--- a/client-react/src/vite-env.d.ts
+++ b/client-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client-react/tailwind.config.ts
+++ b/client-react/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx,jsx,js}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#1677ff",
+          dark: "#0958d9"
+        }
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/client-react/tsconfig.json
+++ b/client-react/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noFallthroughCasesInSwitch": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/client-react/tsconfig.node.json
+++ b/client-react/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: "0.0.0.0"
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a new React 18 + Vite 7 frontend in the client-react directory with Tailwind CSS v4 and Ant Design 5
- add shared layout, navigation components, and a sample dashboard page demonstrating Tailwind utility classes with Ant Design widgets
- document available scripts and usage in the new client-react README and update the root README to point to the refactored frontend

## Testing
- not run (project dependencies are not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c9291ef224832da7abd7dc3538e6d1