### PR TITLE
Add Go tests and API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# API 文档说明
+
+本目录包含后端核心接口的 OpenAPI 3.0 规范文件，方便通过 Swagger UI、Redoc 等工具生成可交互的在线文档。
+
+## 文件结构
+
+- `openapi.yaml`：Vue2 Blog Service 的完整接口描述，覆盖 Auth、Article、Message 等核心模块。
+
+## 本地查看方式
+
+### 使用 Docker 运行 Swagger UI
+
+1. 确保本地已安装 Docker。
+2. 在仓库根目录执行以下命令启动 Swagger UI：
+
+   ```bash
+   docker run --rm -p 8081:8080 \
+     -e SWAGGER_JSON=/tmp/openapi.yaml \
+     -v "$(pwd)/docs/openapi.yaml:/tmp/openapi.yaml" \
+     swaggerapi/swagger-ui
+   ```
+
+3. 打开浏览器访问 [http://localhost:8081](http://localhost:8081) 即可查看文档。
+
+### 使用 Node 工具（可选）
+
+如果希望使用本地静态文件服务器，也可以借助 `redoc-cli` 生成 HTML 页面：
+
+```bash
+npm install -g redoc-cli
+redoc-cli serve docs/openapi.yaml
+```
+
+默认会在 `http://localhost:8080` 提供交互式文档。
+
+## 更新规范
+
+- 修改接口后请同步更新 `openapi.yaml`，确保字段描述、请求参数与实际实现保持一致。
+- 建议使用 [Swagger Editor](https://editor.swagger.io/) 对 YAML 文件进行校验，以保证语法正确。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,472 @@
+openapi: 3.0.3
+info:
+  title: Vue2 Blog Service API
+  version: 1.0.0
+  description: |
+    OpenAPI specification for the Vue2 Blog backend service. All responses are wrapped
+    in the standard envelope `{ "code": number, "msg": string, "data": any }`.
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+security:
+  - bearerAuth: []
+paths:
+  /api/v1/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new user
+      description: Create a user account with a username, password and verification code.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRegisterRequest'
+      responses:
+        '200':
+          description: Registration success message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicResponse'
+  /api/v1/auth/login:
+    post:
+      tags: [Auth]
+      summary: User login
+      description: Authenticate a user and receive a JWT token. Token is also returned in the `Set-Cookie` header.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserLoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          token:
+                            type: string
+                            description: Access token to be used with the Authorization header.
+                          user:
+                            $ref: '#/components/schemas/User'
+  /api/v1/auth/logout:
+    post:
+      tags: [Auth]
+      summary: Logout
+      description: Clears the login cookie on the client.
+      responses:
+        '200':
+          description: Logout success message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicResponse'
+  /api/v1/auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Refresh access token
+      description: Provide a refresh token via the `Refresh-Token` header to obtain a new access token.
+      security: []
+      parameters:
+        - in: header
+          name: Refresh-Token
+          required: true
+          schema:
+            type: string
+          description: Refresh token previously issued to the client.
+      responses:
+        '200':
+          description: New token issued
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          token:
+                            type: string
+  /api/v1/auth/profile:
+    get:
+      tags: [Auth]
+      summary: Get current user profile
+      description: Requires a valid JWT token in the `Authorization` header or `token` cookie.
+      responses:
+        '200':
+          description: User profile information
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          userInfo:
+                            $ref: '#/components/schemas/User'
+  /api/v1/articles:
+    get:
+      tags: [Articles]
+      summary: List articles
+      description: Retrieve a paginated list of articles. Content field is omitted in list responses.
+      parameters:
+        - in: query
+          name: tag
+          schema:
+            type: string
+          description: Filter by tag.
+        - in: query
+          name: skip
+          schema:
+            type: integer
+            minimum: 0
+          description: Number of documents to skip.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+          description: Page size. Defaults to 5.
+      responses:
+        '200':
+          description: Article list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Article'
+  /api/v1/articles/{id}:
+    get:
+      tags: [Articles]
+      summary: Get article by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: MongoDB ObjectID of the article.
+      responses:
+        '200':
+          description: Article details (content included)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ArticleDetail'
+  /api/v1/articles/hot:
+    get:
+      tags: [Articles]
+      summary: List hot articles
+      description: Returns articles sorted by page views.
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+          description: Number of articles to return. Defaults to 8.
+      responses:
+        '200':
+          description: Hot articles
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Article'
+  /api/v1/articles/search:
+    post:
+      tags: [Articles]
+      summary: Search articles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArticleSearchRequest'
+      responses:
+        '200':
+          description: Matching articles
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Article'
+  /api/v1/articles/info:
+    get:
+      tags: [Articles]
+      summary: Get article statistics
+      responses:
+        '200':
+          description: Article info summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ArticleInfo'
+  /api/v1/messages:
+    get:
+      tags: [Messages]
+      summary: List messages
+      parameters:
+        - in: query
+          name: skip
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+          description: Defaults to 5 when not supplied.
+      responses:
+        '200':
+          description: Paginated message list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BasicResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Message'
+    post:
+      tags: [Messages]
+      summary: Create a new message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageCreateRequest'
+      responses:
+        '200':
+          description: Message created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicResponse'
+  /api/v1/messages/{id}/replies:
+    post:
+      tags: [Messages]
+      summary: Reply to a message
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Target message ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageReplyRequest'
+      responses:
+        '200':
+          description: Reply created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicResponse'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    BasicResponse:
+      type: object
+      required: [code, msg]
+      properties:
+        code:
+          type: integer
+          description: Application level status code.
+        msg:
+          type: string
+        data:
+          description: Response payload. Null when not applicable.
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          description: MongoDB ObjectID.
+        user:
+          type: string
+        regDate:
+          type: integer
+          format: int64
+          description: Registration timestamp in milliseconds.
+        photo:
+          type: string
+        disabled:
+          type: boolean
+        admin:
+          type: boolean
+    UserLoginRequest:
+      type: object
+      required: [user, pwd]
+      properties:
+        user:
+          type: string
+          minLength: 2
+          maxLength: 7
+        pwd:
+          type: string
+          minLength: 6
+          maxLength: 18
+    UserRegisterRequest:
+      type: object
+      required: [user, pwd, vcode]
+      properties:
+        user:
+          type: string
+          minLength: 2
+          maxLength: 7
+        pwd:
+          type: string
+          minLength: 6
+          maxLength: 18
+        vcode:
+          type: string
+    Article:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          description: Article type, e.g. 原创 or 转载.
+        title:
+          type: string
+        tag:
+          type: string
+        updateDate:
+          type: string
+          format: date-time
+        date:
+          type: string
+          format: date-time
+        surface:
+          type: string
+          description: Cover image URL.
+        pv:
+          type: integer
+          format: int64
+    ArticleDetail:
+      allOf:
+        - $ref: '#/components/schemas/Article'
+        - type: object
+          properties:
+            content:
+              type: string
+    ArticleSearchRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+    ArticleInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        num:
+          type: integer
+          format: int64
+    Message:
+      type: object
+      properties:
+        id:
+          type: string
+        user:
+          $ref: '#/components/schemas/User'
+        content:
+          type: string
+        date:
+          type: string
+          format: date-time
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/MessageChild'
+    MessageChild:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        content:
+          type: string
+        reUser:
+          type: string
+        date:
+          type: string
+          format: date-time
+    MessageCreateRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+    MessageReplyRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+        reUser:
+          type: string

--- a/server-go/internal/service/article_service.go
+++ b/server-go/internal/service/article_service.go
@@ -9,11 +9,24 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-type ArticleService struct {
-	articleRepo *repository.ArticleRepository
+// ArticleRepository 定义文章仓储需要实现的方法
+type ArticleRepository interface {
+	FindList(ctx context.Context, tag string, skip, limit int) ([]*model.Article, error)
+	FindByID(ctx context.Context, id primitive.ObjectID) (*model.Article, error)
+	IncrementPV(ctx context.Context, id primitive.ObjectID) error
+	FindHot(ctx context.Context, limit int) ([]*model.Article, error)
+	Search(ctx context.Context, content string) ([]*model.Article, error)
+	GetInfo(ctx context.Context) (*model.ArticleInfo, error)
 }
 
-func NewArticleService(articleRepo *repository.ArticleRepository) *ArticleService {
+// 确保实际仓储实现接口
+var _ ArticleRepository = (*repository.ArticleRepository)(nil)
+
+type ArticleService struct {
+	articleRepo ArticleRepository
+}
+
+func NewArticleService(articleRepo ArticleRepository) *ArticleService {
 	return &ArticleService{
 		articleRepo: articleRepo,
 	}

--- a/server-go/internal/service/message_service.go
+++ b/server-go/internal/service/message_service.go
@@ -9,12 +9,30 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-type MessageService struct {
-	messageRepo *repository.MessageRepository
-	userRepo    *repository.UserRepository
+// MessageRepository 定义留言仓储接口
+type MessageRepository interface {
+	Create(ctx context.Context, message *model.Message) error
+	AddChildMessage(ctx context.Context, messageID primitive.ObjectID, child model.MessageChild) error
+	FindList(ctx context.Context, skip, limit int) ([]*model.Message, error)
 }
 
-func NewMessageService(messageRepo *repository.MessageRepository, userRepo *repository.UserRepository) *MessageService {
+// UserRepository 定义用户仓储接口（留言模块需要的能力）
+type UserRepository interface {
+	FindByID(ctx context.Context, id primitive.ObjectID) (*model.User, error)
+}
+
+// 接口实现断言
+var (
+	_ MessageRepository = (*repository.MessageRepository)(nil)
+	_ UserRepository    = (*repository.UserRepository)(nil)
+)
+
+type MessageService struct {
+	messageRepo MessageRepository
+	userRepo    UserRepository
+}
+
+func NewMessageService(messageRepo MessageRepository, userRepo UserRepository) *MessageService {
 	return &MessageService{
 		messageRepo: messageRepo,
 		userRepo:    userRepo,

--- a/server-go/test/article_service_test.go
+++ b/server-go/test/article_service_test.go
@@ -1,0 +1,212 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"vue2-blog-server/internal/model"
+	"vue2-blog-server/internal/service"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type mockArticleRepository struct {
+	findListFunc    func(ctx context.Context, tag string, skip, limit int) ([]*model.Article, error)
+	findByIDFunc    func(ctx context.Context, id primitive.ObjectID) (*model.Article, error)
+	incrementPVFunc func(ctx context.Context, id primitive.ObjectID) error
+	findHotFunc     func(ctx context.Context, limit int) ([]*model.Article, error)
+	searchFunc      func(ctx context.Context, content string) ([]*model.Article, error)
+	getInfoFunc     func(ctx context.Context) (*model.ArticleInfo, error)
+}
+
+var _ service.ArticleRepository = (*mockArticleRepository)(nil)
+
+func (m *mockArticleRepository) FindList(ctx context.Context, tag string, skip, limit int) ([]*model.Article, error) {
+	if m.findListFunc != nil {
+		return m.findListFunc(ctx, tag, skip, limit)
+	}
+	return nil, errors.New("findListFunc not implemented")
+}
+
+func (m *mockArticleRepository) FindByID(ctx context.Context, id primitive.ObjectID) (*model.Article, error) {
+	if m.findByIDFunc != nil {
+		return m.findByIDFunc(ctx, id)
+	}
+	return nil, errors.New("findByIDFunc not implemented")
+}
+
+func (m *mockArticleRepository) IncrementPV(ctx context.Context, id primitive.ObjectID) error {
+	if m.incrementPVFunc != nil {
+		return m.incrementPVFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockArticleRepository) FindHot(ctx context.Context, limit int) ([]*model.Article, error) {
+	if m.findHotFunc != nil {
+		return m.findHotFunc(ctx, limit)
+	}
+	return nil, errors.New("findHotFunc not implemented")
+}
+
+func (m *mockArticleRepository) Search(ctx context.Context, content string) ([]*model.Article, error) {
+	if m.searchFunc != nil {
+		return m.searchFunc(ctx, content)
+	}
+	return nil, errors.New("searchFunc not implemented")
+}
+
+func (m *mockArticleRepository) GetInfo(ctx context.Context) (*model.ArticleInfo, error) {
+	if m.getInfoFunc != nil {
+		return m.getInfoFunc(ctx)
+	}
+	return nil, errors.New("getInfoFunc not implemented")
+}
+
+func TestArticleServiceGetListTransformsArticles(t *testing.T) {
+	repo := &mockArticleRepository{
+		findListFunc: func(ctx context.Context, tag string, skip, limit int) ([]*model.Article, error) {
+			if tag != "Go" {
+				t.Fatalf("expected tag Go, got %s", tag)
+			}
+			if skip != 2 || limit != 5 {
+				t.Fatalf("unexpected pagination values skip=%d limit=%d", skip, limit)
+			}
+			return []*model.Article{{
+				ID:      primitive.NewObjectID(),
+				Type:    "原创",
+				Title:   "Concurrency Patterns",
+				Content: "goroutines",
+				Tag:     tag,
+				Date:    time.Now(),
+			}}, nil
+		},
+	}
+
+	service := service.NewArticleService(repo)
+	req := &model.ArticleListRequest{Tag: "Go", Skip: 2, Limit: 5}
+	articles, err := service.GetList(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetList returned error: %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+	if articles[0].Content != "" {
+		t.Fatalf("expected content to be omitted in list response")
+	}
+}
+
+func TestArticleServiceGetByIDIncrementsPV(t *testing.T) {
+	articleID := primitive.NewObjectID()
+	incrementCh := make(chan primitive.ObjectID, 1)
+	repo := &mockArticleRepository{
+		findByIDFunc: func(ctx context.Context, id primitive.ObjectID) (*model.Article, error) {
+			if id != articleID {
+				t.Fatalf("expected id %s, got %s", articleID.Hex(), id.Hex())
+			}
+			return &model.Article{
+				ID:      id,
+				Type:    "原创",
+				Title:   "Understanding Channels",
+				Content: "channels are powerful",
+				Tag:     "Go",
+				Date:    time.Now(),
+			}, nil
+		},
+		incrementPVFunc: func(ctx context.Context, id primitive.ObjectID) error {
+			incrementCh <- id
+			return nil
+		},
+	}
+
+	service := service.NewArticleService(repo)
+	article, err := service.GetByID(context.Background(), articleID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if article.Content == "" {
+		t.Fatalf("expected detailed view to include content")
+	}
+
+	select {
+	case got := <-incrementCh:
+		if got != articleID {
+			t.Fatalf("expected increment for %s, got %s", articleID.Hex(), got.Hex())
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected IncrementPV to be called")
+	}
+}
+
+func TestArticleServiceGetHotUsesDefaultLimit(t *testing.T) {
+	capturedLimit := 0
+	repo := &mockArticleRepository{
+		findHotFunc: func(ctx context.Context, limit int) ([]*model.Article, error) {
+			capturedLimit = limit
+			return []*model.Article{{
+				ID:    primitive.NewObjectID(),
+				Type:  "原创",
+				Title: "Hot Article",
+				Tag:   "Go",
+				Date:  time.Now(),
+			}}, nil
+		},
+	}
+
+	service := service.NewArticleService(repo)
+	req := &model.ArticleHotRequest{}
+	articles, err := service.GetHot(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetHot returned error: %v", err)
+	}
+	if capturedLimit != 8 {
+		t.Fatalf("expected default limit 8, got %d", capturedLimit)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+	if articles[0].Content != "" {
+		t.Fatalf("expected content omitted for hot articles")
+	}
+}
+
+func TestArticleServiceSearchAndGetInfo(t *testing.T) {
+	repo := &mockArticleRepository{
+		searchFunc: func(ctx context.Context, content string) ([]*model.Article, error) {
+			if content != "golang" {
+				t.Fatalf("expected search term golang, got %s", content)
+			}
+			return []*model.Article{{
+				ID:      primitive.NewObjectID(),
+				Type:    "原创",
+				Title:   "Searching Go",
+				Content: "golang tips",
+				Tag:     "Go",
+				Date:    time.Now(),
+			}}, nil
+		},
+		getInfoFunc: func(ctx context.Context) (*model.ArticleInfo, error) {
+			return &model.ArticleInfo{Tags: []string{"Go"}, Num: 1}, nil
+		},
+	}
+
+	service := service.NewArticleService(repo)
+	articles, err := service.Search(context.Background(), &model.ArticleSearchRequest{Content: "golang"})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+
+	info, err := service.GetInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetInfo returned error: %v", err)
+	}
+	if info.Num != 1 || len(info.Tags) != 1 || info.Tags[0] != "Go" {
+		t.Fatalf("unexpected info payload: %+v", info)
+	}
+}

--- a/server-go/test/auth_test.go
+++ b/server-go/test/auth_test.go
@@ -1,0 +1,93 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"vue2-blog-server/internal/auth"
+	"vue2-blog-server/internal/model"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestJWTManagerGenerateAndParseToken(t *testing.T) {
+	manager := auth.NewJWTManager("secret", time.Minute, time.Hour)
+	user := &model.UserDTO{
+		ID:    primitive.NewObjectID(),
+		User:  "tester",
+		Admin: true,
+	}
+
+	token, err := manager.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("GenerateToken returned error: %v", err)
+	}
+
+	claims, err := manager.ParseToken(token)
+	if err != nil {
+		t.Fatalf("ParseToken returned error: %v", err)
+	}
+
+	if claims.UserID != user.ID {
+		t.Fatalf("expected user id %s, got %s", user.ID.Hex(), claims.UserID.Hex())
+	}
+
+	if claims.Username != user.User {
+		t.Fatalf("expected username %s, got %s", user.User, claims.Username)
+	}
+
+	if claims.Admin != user.Admin {
+		t.Fatalf("expected admin %t, got %t", user.Admin, claims.Admin)
+	}
+
+	if claims.ExpiresAt == nil || claims.ExpiresAt.Time.Before(time.Now()) {
+		t.Fatalf("expected valid expiration, got %v", claims.ExpiresAt)
+	}
+}
+
+func TestJWTManagerRefreshToken(t *testing.T) {
+	manager := auth.NewJWTManager("secret", time.Minute, time.Hour)
+	user := &model.UserDTO{
+		ID:    primitive.NewObjectID(),
+		User:  "tester",
+		Admin: false,
+	}
+
+	refreshToken, err := manager.GenerateRefreshToken(user)
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken returned error: %v", err)
+	}
+
+	newToken, err := manager.RefreshToken(refreshToken)
+	if err != nil {
+		t.Fatalf("RefreshToken returned error: %v", err)
+	}
+
+	if newToken == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	claims, err := manager.ParseToken(newToken)
+	if err != nil {
+		t.Fatalf("ParseToken returned error: %v", err)
+	}
+
+	if claims.UserID != user.ID {
+		t.Fatalf("expected refreshed token to contain same user id")
+	}
+
+	if claims.ExpiresAt == nil || claims.ExpiresAt.Time.Before(time.Now()) {
+		t.Fatalf("expected refreshed token to have future expiration")
+	}
+}
+
+func TestJWTManagerParseInvalidToken(t *testing.T) {
+	manager := auth.NewJWTManager("secret", time.Minute, time.Hour)
+	if _, err := manager.ParseToken("invalid-token"); err == nil {
+		t.Fatal("expected error when parsing invalid token")
+	}
+
+	if _, err := manager.RefreshToken("invalid-token"); err == nil {
+		t.Fatal("expected error when refreshing invalid token")
+	}
+}

--- a/server-go/test/message_service_test.go
+++ b/server-go/test/message_service_test.go
@@ -1,0 +1,178 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"vue2-blog-server/internal/model"
+	"vue2-blog-server/internal/service"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type mockMessageRepository struct {
+	createFunc   func(ctx context.Context, message *model.Message) error
+	addChildFunc func(ctx context.Context, messageID primitive.ObjectID, child model.MessageChild) error
+	findListFunc func(ctx context.Context, skip, limit int) ([]*model.Message, error)
+}
+
+type mockUserRepository struct {
+	findByIDFunc func(ctx context.Context, id primitive.ObjectID) (*model.User, error)
+}
+
+var (
+	_ service.MessageRepository = (*mockMessageRepository)(nil)
+	_ service.UserRepository    = (*mockUserRepository)(nil)
+)
+
+func (m *mockMessageRepository) Create(ctx context.Context, message *model.Message) error {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, message)
+	}
+	return errors.New("createFunc not implemented")
+}
+
+func (m *mockMessageRepository) AddChildMessage(ctx context.Context, messageID primitive.ObjectID, child model.MessageChild) error {
+	if m.addChildFunc != nil {
+		return m.addChildFunc(ctx, messageID, child)
+	}
+	return errors.New("addChildFunc not implemented")
+}
+
+func (m *mockMessageRepository) FindList(ctx context.Context, skip, limit int) ([]*model.Message, error) {
+	if m.findListFunc != nil {
+		return m.findListFunc(ctx, skip, limit)
+	}
+	return nil, errors.New("findListFunc not implemented")
+}
+
+func (m *mockUserRepository) FindByID(ctx context.Context, id primitive.ObjectID) (*model.User, error) {
+	if m.findByIDFunc != nil {
+		return m.findByIDFunc(ctx, id)
+	}
+	return nil, errors.New("findByIDFunc not implemented")
+}
+
+func TestMessageServiceCreate(t *testing.T) {
+	var captured *model.Message
+	messageRepo := &mockMessageRepository{
+		createFunc: func(ctx context.Context, message *model.Message) error {
+			captured = message
+			return nil
+		},
+	}
+
+	svc := service.NewMessageService(messageRepo, &mockUserRepository{})
+	userID := primitive.NewObjectID()
+	req := &model.MessageCreateRequest{Content: "Great post!"}
+	if err := svc.Create(context.Background(), userID, req); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("expected create to be called")
+	}
+	if captured.User != userID {
+		t.Fatalf("expected message user %s, got %s", userID.Hex(), captured.User.Hex())
+	}
+	if captured.Content != req.Content {
+		t.Fatalf("expected message content %s, got %s", req.Content, captured.Content)
+	}
+	if captured.Children != nil {
+		t.Fatalf("expected children to be nil slice prior to persistence")
+	}
+}
+
+func TestMessageServiceAddReply(t *testing.T) {
+	var (
+		capturedMessageID primitive.ObjectID
+		capturedChild     model.MessageChild
+	)
+	messageRepo := &mockMessageRepository{
+		addChildFunc: func(ctx context.Context, messageID primitive.ObjectID, child model.MessageChild) error {
+			capturedMessageID = messageID
+			capturedChild = child
+			return nil
+		},
+	}
+
+	svc := service.NewMessageService(messageRepo, &mockUserRepository{})
+	messageID := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+	req := &model.MessageReplyRequest{Content: "Thanks!", ReUser: "Author"}
+
+	if err := svc.AddReply(context.Background(), messageID, userID, req); err != nil {
+		t.Fatalf("AddReply returned error: %v", err)
+	}
+
+	if capturedMessageID != messageID {
+		t.Fatalf("expected message ID %s, got %s", messageID.Hex(), capturedMessageID.Hex())
+	}
+	if capturedChild.User != userID {
+		t.Fatalf("expected reply user %s, got %s", userID.Hex(), capturedChild.User.Hex())
+	}
+	if capturedChild.Content != req.Content || capturedChild.ReUser != req.ReUser {
+		t.Fatalf("unexpected reply payload: %+v", capturedChild)
+	}
+}
+
+func TestMessageServiceGetListTransformsMessages(t *testing.T) {
+	userID := primitive.NewObjectID()
+	childUserID := primitive.NewObjectID()
+	missingUserID := primitive.NewObjectID()
+	now := time.Now()
+
+	messageRepo := &mockMessageRepository{
+		findListFunc: func(ctx context.Context, skip, limit int) ([]*model.Message, error) {
+			if skip != 0 || limit != 10 {
+				t.Fatalf("unexpected pagination skip=%d limit=%d", skip, limit)
+			}
+			return []*model.Message{{
+				ID:      primitive.NewObjectID(),
+				User:    userID,
+				Content: "First!",
+				Date:    now,
+				Children: []model.MessageChild{
+					{User: childUserID, Content: "Nice article", ReUser: "tester", Date: now.Add(time.Minute)},
+					{User: missingUserID, Content: "spam"},
+				},
+			}}, nil
+		},
+	}
+
+	userRepo := &mockUserRepository{
+		findByIDFunc: func(ctx context.Context, id primitive.ObjectID) (*model.User, error) {
+			switch id {
+			case userID:
+				return &model.User{ID: id, User: "owner", Photo: "avatar.jpg"}, nil
+			case childUserID:
+				return &model.User{ID: id, User: "commenter", Photo: "user.jpg"}, nil
+			default:
+				return nil, errors.New("not found")
+			}
+		},
+	}
+
+	svc := service.NewMessageService(messageRepo, userRepo)
+	messages, err := svc.GetList(context.Background(), &model.MessageListRequest{Limit: 10})
+	if err != nil {
+		t.Fatalf("GetList returned error: %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	msg := messages[0]
+	if msg.User == nil || msg.User.User != "owner" {
+		t.Fatalf("expected owner user info, got %+v", msg.User)
+	}
+	if len(msg.Children) != 1 {
+		t.Fatalf("expected missing child to be skipped, children=%d", len(msg.Children))
+	}
+	if msg.Children[0].User == nil || msg.Children[0].User.User != "commenter" {
+		t.Fatalf("unexpected child dto: %+v", msg.Children[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add repository interfaces to the Go services to enable mocking in unit tests
- create auth, article, and message unit test suites under server-go/test
- provide Swagger/OpenAPI documentation and usage instructions in the new docs directory

## Testing
- go test ./... *(fails: module downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c925045928832d9eb97519f8e26797