### PR TITLE
Improve server shutdown and verification robustness

### DIFF
--- a/server-go/internal/handler/auth_handler.go
+++ b/server-go/internal/handler/auth_handler.go
@@ -9,6 +9,7 @@ import (
 	"image/draw"
 	"image/png"
 	"net/http"
+	"sync"
 
 	"vue2-blog-server/internal/auth"
 	"vue2-blog-server/internal/model"
@@ -25,6 +26,7 @@ type AuthHandler struct {
 	jwtManager   *auth.JWTManager
 	validator    *validator.Validate
 	vcodeStorage map[string]string // 临时存储验证码，生产环境应使用Redis
+	vcodeMu      sync.RWMutex
 }
 
 func NewAuthHandler(userService *service.UserService, jwtManager *auth.JWTManager) *AuthHandler {
@@ -39,7 +41,7 @@ func NewAuthHandler(userService *service.UserService, jwtManager *auth.JWTManage
 // Register 用户注册
 func (h *AuthHandler) Register(c *gin.Context) {
 	var req model.UserRegisterRequest
-	
+
 	// 支持form数据和JSON数据
 	if user := c.PostForm("user"); user != "" {
 		req.User = user
@@ -62,16 +64,18 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	if sessionKey == "" {
 		sessionKey = c.PostForm("sessionKey")
 	}
-	
-	if sessionKey != "" && h.vcodeStorage[sessionKey] != "" {
-		if h.vcodeStorage[sessionKey] != req.Vcode {
-			pkg.ValidateError(c, "验证码错误")
-			return
+
+	if sessionKey != "" {
+		if storedCode, exists := h.getVCode(sessionKey); exists && storedCode != "" {
+			if storedCode != req.Vcode {
+				pkg.ValidateError(c, "验证码错误")
+				return
+			}
+			// 验证成功后删除验证码
+			h.deleteVCode(sessionKey)
 		}
-		// 验证成功后删除验证码
-		delete(h.vcodeStorage, sessionKey)
 	}
-	
+
 	err := h.userService.Register(c.Request.Context(), &req)
 	if err != nil {
 		pkg.Error(c, err.Error())
@@ -84,7 +88,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 // Login 用户登录
 func (h *AuthHandler) Login(c *gin.Context) {
 	var req model.UserLoginRequest
-	
+
 	// 支持form数据和JSON数据
 	if user := c.PostForm("user"); user != "" {
 		req.User = user
@@ -127,7 +131,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 func (h *AuthHandler) Logout(c *gin.Context) {
 	// 清除Cookie
 	c.SetCookie("token", "", -1, "/", "", false, true)
-	
+
 	pkg.SuccessWithMsg(c, "退出登录成功", nil)
 }
 
@@ -203,17 +207,29 @@ func (h *AuthHandler) CheckLoginLegacy(c *gin.Context) {
 // GenerateVCode 生成验证码
 func (h *AuthHandler) GenerateVCode(c *gin.Context) {
 	// 生成随机字符串作为验证码
-	code := h.generateRandomCode(4)
-	
+	code, err := h.generateRandomCode(4)
+	if err != nil {
+		pkg.ServerError(c, "生成验证码失败")
+		return
+	}
+
 	// 生成会话key
-	sessionKey := h.generateSessionKey()
-	
+	sessionKey, err := h.generateSessionKey()
+	if err != nil {
+		pkg.ServerError(c, "生成会话标识失败")
+		return
+	}
+
 	// 存储验证码
-	h.vcodeStorage[sessionKey] = code
-	
+	h.setVCode(sessionKey, code)
+
 	// 生成SVG图片
-	svgImg := h.generateCodeImage(code)
-	
+	svgImg, err := h.generateCodeImage(code)
+	if err != nil {
+		pkg.ServerError(c, "生成验证码图片失败")
+		return
+	}
+
 	c.Header("X-Session-Key", sessionKey)
 	pkg.Success(c, gin.H{
 		"svgCode":    svgImg,
@@ -228,57 +244,88 @@ func (h *AuthHandler) CheckVCode(c *gin.Context) {
 	if sessionKey == "" {
 		sessionKey = c.PostForm("sessionKey")
 	}
-	
+
 	if sessionKey == "" {
 		pkg.ValidateError(c, "缺少会话标识")
 		return
 	}
-	
-	storedCode, exists := h.vcodeStorage[sessionKey]
+
+	storedCode, exists := h.getVCode(sessionKey)
 	if !exists {
 		pkg.ValidateError(c, "验证码已过期")
 		return
 	}
-	
+
 	if storedCode != svgCode {
 		pkg.ValidateError(c, "验证码错误")
 		return
 	}
-	
+
 	pkg.Success(c, gin.H{"valid": true})
 }
 
 // generateRandomCode 生成随机验证码
-func (h *AuthHandler) generateRandomCode(length int) string {
-	chars := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+func (h *AuthHandler) generateRandomCode(length int) (string, error) {
+	const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 	code := make([]byte, length)
-	for i := 0; i < length; i++ {
-		b := make([]byte, 1)
-		rand.Read(b)
-		code[i] = chars[int(b[0])%len(chars)]
+	if _, err := rand.Read(code); err != nil {
+		return "", err
 	}
-	return string(code)
+
+	for i := range code {
+		code[i] = chars[int(code[i])%len(chars)]
+	}
+
+	return string(code), nil
 }
 
 // generateSessionKey 生成会话key
-func (h *AuthHandler) generateSessionKey() string {
+func (h *AuthHandler) generateSessionKey() (string, error) {
 	b := make([]byte, 16)
-	rand.Read(b)
-	return base64.URLEncoding.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
 }
 
 // generateCodeImage 生成验证码图片
-func (h *AuthHandler) generateCodeImage(code string) string {
+func (h *AuthHandler) generateCodeImage(code string) (string, error) {
 	// 创建简单的验证码图片
 	width, height := 120, 40
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
-	
+
 	// 填充白色背景
 	draw.Draw(img, img.Bounds(), &image.Uniform{color.RGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
-	
+
 	// 这里应该绘制验证码文字，为了简化，我们返回base64编码的PNG
 	var buf bytes.Buffer
-	png.Encode(&buf, img)
-	
-	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+	if err := png.Encode(&buf, img); err != nil {
+		return "", err
+	}
+
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func (h *AuthHandler) getVCode(sessionKey string) (string, bool) {
+	h.vcodeMu.RLock()
+	defer h.vcodeMu.RUnlock()
+
+	code, exists := h.vcodeStorage[sessionKey]
+	return code, exists
+}
+
+func (h *AuthHandler) setVCode(sessionKey, code string) {
+	h.vcodeMu.Lock()
+	defer h.vcodeMu.Unlock()
+
+	h.vcodeStorage[sessionKey] = code
+}
+
+func (h *AuthHandler) deleteVCode(sessionKey string) {
+	h.vcodeMu.Lock()
+	defer h.vcodeMu.Unlock()
+
+	delete(h.vcodeStorage, sessionKey)
 }

--- a/server-go/internal/middleware/recovery.go
+++ b/server-go/internal/middleware/recovery.go
@@ -27,6 +27,6 @@ func RecoveryMiddleware(logger *zap.Logger) gin.HandlerFunc {
 		}
 
 		pkg.ServerError(c, "服务器内部错误")
-		c.AbortWithStatus(http.StatusInternalServerError)
+		c.Abort()
 	})
 }

--- a/server-go/internal/server/server.go
+++ b/server-go/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -19,6 +20,7 @@ type Server struct {
 	logger     *zap.Logger
 	jwtManager *auth.JWTManager
 	handlers   *Handlers
+	httpServer *http.Server
 }
 
 type Handlers struct {
@@ -40,9 +42,9 @@ func NewServer(logger *zap.Logger, jwtManager *auth.JWTManager, handlers *Handle
 func (s *Server) Initialize() {
 	// 设置生产模式
 	gin.SetMode(gin.ReleaseMode)
-	
+
 	s.router = gin.New()
-	
+
 	// 添加全局中间件
 	s.router.Use(middleware.CORSMiddleware())
 	s.router.Use(middleware.StructuredLoggerMiddleware(s.logger))
@@ -62,7 +64,7 @@ func (s *Server) Initialize() {
 
 func (s *Server) registerRoutes() {
 	api := s.router.Group("/api/v1")
-	
+
 	// 认证相关路由
 	auth := api.Group("/auth")
 	{
@@ -70,7 +72,7 @@ func (s *Server) registerRoutes() {
 		auth.POST("/login", s.handlers.AuthHandler.Login)
 		auth.POST("/logout", s.handlers.AuthHandler.Logout)
 		auth.POST("/refresh", s.handlers.AuthHandler.RefreshToken)
-		
+
 		// 需要认证的路由
 		authRequired := auth.Group("")
 		authRequired.Use(middleware.AuthMiddleware(s.jwtManager))
@@ -93,7 +95,7 @@ func (s *Server) registerRoutes() {
 	messages := api.Group("/messages")
 	{
 		messages.GET("", s.handlers.MessageHandler.GetList)
-		
+
 		// 需要认证的路由
 		messageAuth := messages.Group("")
 		messageAuth.Use(middleware.AuthMiddleware(s.jwtManager))
@@ -123,7 +125,7 @@ func (s *Server) registerRoutes() {
 func (s *Server) registerLegacyRoutes() {
 	// 兼容旧版接口
 	legacy := s.router.Group("")
-	
+
 	// 文章接口兼容 - 修复请求方式为POST并支持form数据
 	legacy.POST("/article/getInfo", s.wrapFormHandler(s.handlers.ArticleHandler.GetInfo))
 	legacy.POST("/article/getHot", s.wrapFormHandler(s.handlers.ArticleHandler.GetHot))
@@ -149,7 +151,7 @@ func (s *Server) registerLegacyRoutes() {
 			pkg.ValidateError(c, "缺少搜索关键词")
 		}
 	}))
-	
+
 	// 添加延伸阅读接口
 	legacy.POST("/article/extend", s.wrapFormHandler(s.handlers.ArticleHandler.GetExtend))
 
@@ -158,7 +160,7 @@ func (s *Server) registerLegacyRoutes() {
 	{
 		login.POST("", s.wrapFormHandler(s.handlers.AuthHandler.Login))
 		login.POST("/logout", s.wrapFormHandler(s.handlers.AuthHandler.Logout))
-		
+
 		// 可选认证中间件
 		login.Use(middleware.OptionalAuthMiddleware(s.jwtManager))
 		login.POST("/ifLogin", s.wrapFormHandler(s.handlers.AuthHandler.CheckLoginLegacy))
@@ -176,7 +178,7 @@ func (s *Server) registerLegacyRoutes() {
 	message := legacy.Group("/message")
 	{
 		message.POST("/getList", s.wrapFormHandler(s.handlers.MessageHandler.GetList))
-		
+
 		messageAuth := message.Group("")
 		messageAuth.Use(middleware.AuthMiddleware(s.jwtManager))
 		{
@@ -224,9 +226,13 @@ func (s *Server) healthCheck(c *gin.Context) {
 }
 
 func (s *Server) Start(addr string) error {
+	if s.router == nil {
+		return errors.New("router has not been initialized")
+	}
+
 	s.logger.Info("Starting server", zap.String("address", addr))
-	
-	srv := &http.Server{
+
+	s.httpServer = &http.Server{
 		Addr:         addr,
 		Handler:      s.router,
 		ReadTimeout:  30 * time.Second,
@@ -234,15 +240,22 @@ func (s *Server) Start(addr string) error {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	return srv.ListenAndServe()
+	if err := s.httpServer.ListenAndServe(); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down server...")
-	
-	srv := &http.Server{
-		Handler: s.router,
+
+	if s.httpServer == nil {
+		return nil
 	}
-	
-	return srv.Shutdown(ctx)
+
+	return s.httpServer.Shutdown(ctx)
 }


### PR DESCRIPTION
## Summary
- ensure the HTTP server instance is stored so shutdown uses the live listener and treats server-closed as a normal exit
- harden the auth verification code flow with concurrency-safe storage and error handling for randomness and image generation
- adjust recovery middleware to stop double-writing responses during panic recovery

## Testing
- `go test ./...` *(fails: unable to download modules due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68c92dff3ed8832d9db8e3cf904c04fc